### PR TITLE
Tutor search

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -205,7 +205,7 @@ const SearchBar = (props: Props) => {
     }
     else {
         return (
-            <div className='flex'>
+            <div className='flex z-10 h-20 md:h-11'>
                 <div className='my-2 gap-2 grid grid-cols-3 sm:grid-cols-5 items-start'>
                     <div className='bg-gray-400 rounded-sm px-2 py-1 flex gap-2 items-center col-span-3 sm:col-span-2'>
                         <IoSearch className='min-w-[1rem]' />
@@ -225,11 +225,13 @@ const SearchBar = (props: Props) => {
                             ) || (<IoChevronBack className='min-w-[1rem]' />)}
                         </button>
                         {subjectDisplay && (
-                        <ul className='w-full'>
-                            {subjectsOptions.map(subject => (
-                                <li key={subject.subjectID} className='text-center mt-1 bg-secondary border-white border-2 hover:border-black transition-colors'><button key={subject.subjectID} key-subjectid={subject.subjectID} onClick={updateSubject} className='w-full h-full'>{subject.name}</button></li>
-                            ))}
-                        </ul>)}
+                        <div className='border-2 border-gray-400 bg-white max-h-48 overflow-y-auto'>
+                            <ul className='w-full px-1 pb-1'>
+                                {subjectsOptions.map(subject => (
+                                    <li key={subject.subjectID} className='text-center mt-1 bg-secondary border-white border-2 hover:border-black transition-colors'><button key={subject.subjectID} key-subjectid={subject.subjectID} onClick={updateSubject} className='w-full h-full'>{subject.name}</button></li>
+                                ))}
+                            </ul>
+                        </div>)}
                     </div>
                     <div className='rounded-sm gap-2'>
                         <button className='bg-gray-400 flex items-center justify-between w-full h-full px-2 py-1' onClick={toggleDayDisplay}>
@@ -239,11 +241,13 @@ const SearchBar = (props: Props) => {
                             ) || (<IoChevronBack className='min-w-[1rem]' />)}
                         </button>
                         {dayDisplay && (
-                        <ul className='w-full'>
-                            {daysOptions.map(date => (
-                                <li key={date.getTime()} className='text-center mt-1 bg-secondary border-white border-2 hover:border-black transition-colors'><button key={date.getTime()} key-dayid={date.getTime()} onClick={updateDay} className='w-full h-full'>{formatDay(date)}</button></li>
-                            ))}
-                        </ul>)}
+                        <div className='border-2 border-gray-400 bg-white max-h-48 overflow-y-auto'>
+                            <ul className='w-full px-1 pb-1'>
+                                {daysOptions.map(date => (
+                                    <li key={date.getTime()} className='text-center mt-1 bg-secondary border-white border-2 hover:border-black transition-colors'><button key={date.getTime()} key-dayid={date.getTime()} onClick={updateDay} className='w-full h-full'>{formatDay(date)}</button></li>
+                                ))}
+                            </ul>
+                        </div>)}
                     </div>
                     <div className='rounded-sm gap-2'>
                         <button className='bg-gray-400 flex items-center justify-between w-full h-full px-2 py-1' onClick={toggleHourDisplay}>
@@ -253,11 +257,13 @@ const SearchBar = (props: Props) => {
                             ) || (<IoChevronBack className='min-w-[1rem]' />)}
                         </button>
                         {hourDisplay && (
-                        <ul className='w-full'>
-                            {hoursOptions.map(date => (
-                                <li key={date.getHours()} className='text-center mt-1 bg-secondary border-white border-2 hover:border-black transition-colors'><button key={date.getHours()} key-hourid={date.getHours()} onClick={updateHour} className='w-full h-full'>{formatHour(date)}</button></li>
-                            ))}
-                        </ul>)}
+                        <div className='border-2 border-gray-400 bg-white max-h-48 overflow-y-auto'>
+                            <ul className='w-full px-1 pb-1'>
+                                {hoursOptions.map(date => (
+                                    <li key={date.getHours()} className='text-center mt-1 bg-secondary border-white border-2 hover:border-black transition-colors'><button key={date.getHours()} key-hourid={date.getHours()} onClick={updateHour} className='w-full h-full'>{formatHour(date)}</button></li>
+                                ))}
+                            </ul>
+                        </div>)}
                     </div>
                 </div>
                 {filtersApplied && <div className='mt-8 sm:mt-[0.8rem] md:mt-[0.85rem] ml-4 items-start'>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,9 +1,39 @@
-import React from 'react'
+import React, { ChangeEvent } from 'react'
 import { IoChevronDown, IoSearch } from 'react-icons/io5'
 
-type Props = {}
+type Props = {
+    setName: React.Dispatch<React.SetStateAction<string>>;
+    setSubject: React.Dispatch<React.SetStateAction<string>>;
+    setDay: React.Dispatch<React.SetStateAction<Date | undefined>>;
+    setHours: React.Dispatch<React.SetStateAction<Date | undefined>>;
+}
 
 const SearchBar = (props: Props) => {
+    
+    const setName = props.setName, setSubject = props.setSubject, setDay = props.setDay, setHours = props.setHours
+
+    const updateName = (event: ChangeEvent) => {
+        let target = event.target as HTMLInputElement
+        setName(target.value)
+    }
+
+    /*
+    const updateSubject = (event: ChangeEvent) => {
+        let target = event.target as HTMLInputElement
+        setSubject(target.value)
+    }
+    
+    const updateDay = (event: ChangeEvent) => {
+        let target = event.target as HTMLInputElement
+        setDay(target.value)
+    }
+    
+    const updateHours = (event: ChangeEvent) => {
+        let target = event.target as HTMLInputElement
+        setHours(target.value)
+    }
+    */
+
     return (
         <div className='flex'>
             <div className='my-2 gap-2 grid grid-cols-3 sm:grid-cols-5'>
@@ -12,6 +42,7 @@ const SearchBar = (props: Props) => {
                     <input
                         className='placeholder-black text-sm bg-transparent truncate w-full'
                         placeholder='Search Tutors'
+                        onChange={updateName}
                     >
                     </input>
                 </div>
@@ -20,7 +51,7 @@ const SearchBar = (props: Props) => {
                     <IoChevronDown className='min-w-[1rem]' />
                 </button>
                 <button className='bg-gray-400 rounded-sm px-2 py-1 flex items-center justify-center gap-2'>
-                    <span className='text-sm truncate'>Days</span>
+                    <span className='text-sm truncate'>Day</span>
                     <IoChevronDown className='min-w-[1rem]' />
                 </button>
                 <button className='bg-gray-400 rounded-sm px-2 py-1 flex items-center justify-center gap-2'>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,28 +1,79 @@
-import React, { ChangeEvent } from 'react'
-import { IoChevronDown, IoSearch } from 'react-icons/io5'
+import React, { useEffect, ChangeEvent, MouseEventHandler } from 'react'
+import Link from 'next/link'
+import { IoChevronBack, IoChevronDown, IoSearch, IoReload } from 'react-icons/io5'
+import { subject } from '@prisma/client'
 
 type Props = {
     setName: React.Dispatch<React.SetStateAction<string>>;
     setSubject: React.Dispatch<React.SetStateAction<string>>;
     setDay: React.Dispatch<React.SetStateAction<Date | undefined>>;
     setHours: React.Dispatch<React.SetStateAction<Date | undefined>>;
+    subject: string
+    day: Date | undefined
+    hours: Date | undefined
 }
 
 const SearchBar = (props: Props) => {
-    
+    const [isLoading, setLoading] = React.useState<boolean>(true)
+    const [subjects, setSubjects] = React.useState<subject[]>([])
+    const [subjectDisplay, setSubjectDisplay] = React.useState<boolean>(false)
+    const [filtersApplied, setFiltersApplied] = React.useState<boolean>(false)
     const setName = props.setName, setSubject = props.setSubject, setDay = props.setDay, setHours = props.setHours
+    const subject = props.subject, day = props.day, hours = props.hours
+    let nameInput = React.createRef<HTMLInputElement>()
 
-    const updateName = (event: ChangeEvent) => {
+    const fetchSubjects = async () => {
+        await fetch('api/subject', {method: 'GET'})
+        .then((resp) => resp.json())
+        .then((json) => {
+            // read json as tutor array
+            const result = json as subject[]
+            
+            // Check if tutor data is not undefined
+            if(result) {
+                // Update data state
+                setSubjects(result)
+
+                // No longer loading
+                setLoading(false)
+            }
+        })
+        .catch((error) => {
+            setSubjects([])
+            setLoading(false)
+            console.error('error loading subject data')
+            return
+        })
+    }
+
+    const updateName = (event: React.ChangeEvent<HTMLElement>) => {
         let target = event.target as HTMLInputElement
         setName(target.value)
     }
 
-    /*
-    const updateSubject = (event: ChangeEvent) => {
-        let target = event.target as HTMLInputElement
-        setSubject(target.value)
+    const updateSubject = (event: React.MouseEvent<HTMLElement>) => {
+        toggleSubjectDisplay()
+        let target = event.target as HTMLButtonElement
+        //console.log("Subject Key:", target.getAttribute('key-subjectid'))
+        let id = target.getAttribute('key-subjectid')
+        if(id) {
+            // parse id string to int
+            let id_num = parseInt(id)
+            for(let i = 0; i < subjects.length; i++) {
+                if(subjects[i].subjectID == id_num) {
+                    setSubject(subjects[i].name)
+                    return
+                }
+            }
+        }
+        else {
+            console.error('error updating subject')
+            return
+        }
+        console.error('Could not find subject ID', id)
     }
-    
+
+    /*
     const updateDay = (event: ChangeEvent) => {
         let target = event.target as HTMLInputElement
         setDay(target.value)
@@ -34,33 +85,74 @@ const SearchBar = (props: Props) => {
     }
     */
 
-    return (
-        <div className='flex'>
-            <div className='my-2 gap-2 grid grid-cols-3 sm:grid-cols-5'>
-                <div className='bg-gray-400 rounded-sm px-2 py-1 flex gap-2 items-center col-span-3 sm:col-span-2'>
-                    <IoSearch className='min-w-[1rem]' />
-                    <input
-                        className='placeholder-black text-sm bg-transparent truncate w-full'
-                        placeholder='Search Tutors'
-                        onChange={updateName}
-                    >
-                    </input>
+    const resetSearch = () => {
+        // Reset name, clear text input
+        setName("")
+        if(nameInput.current)
+            nameInput.current.value = ""
+        
+        // Reset everything else
+        setSubject("")
+    }
+
+    const toggleSubjectDisplay = () => {
+        setSubjectDisplay(!subjectDisplay)
+    }
+
+    useEffect(() => {
+        fetchSubjects()
+    }, [])
+
+    useEffect(() => {
+        setFiltersApplied((nameInput.current && nameInput.current.value != '') || subject != '')
+    }, [nameInput, subject, day, hours])
+
+    if(isLoading) {
+        return <></>
+    }
+    else {
+        return (
+            <div className='flex'>
+                <div className='my-2 gap-2 grid grid-cols-3 sm:grid-cols-5 items-start'>
+                    <div className='bg-gray-400 rounded-sm px-2 py-1 flex gap-2 items-center col-span-3 sm:col-span-2'>
+                        <IoSearch className='min-w-[1rem]' />
+                        <input
+                            className='placeholder-black text-sm bg-transparent truncate w-full'
+                            placeholder='Search Tutors'
+                            onChange={updateName}
+                            ref={nameInput}
+                        >
+                        </input>
+                    </div>
+                    <div className='rounded-sm gap-2'>
+                        <button className='bg-gray-400 flex items-center justify-between w-full h-full px-2 py-1' onClick={toggleSubjectDisplay}>
+                            <span className='text-sm truncate items-center'>{subject != "" && subject || ('Subject')}</span>
+                            {!subjectDisplay && (
+                                <IoChevronDown className='min-w-[1rem]' />
+                            ) || (<IoChevronBack className='min-w-[1rem]' />)}
+                        </button>
+                        {subjectDisplay && (
+                        <ul className='w-full'>
+                            {subjects.map(subject => (
+                                <li key={subject.subjectID} className='text-center mt-1 bg-secondary border-white border-2 hover:border-black transition-colors'><button key={subject.subjectID} key-subjectid={subject.subjectID} onClick={updateSubject} className='w-full h-full'>{subject.name}</button></li>
+                            ))}
+                        </ul>)}
+                    </div>
+                    <button className='bg-gray-400 rounded-sm px-2 py-1 flex items-center justify-between gap-2'>
+                        <span className='text-sm truncate'>Day</span>
+                        <IoChevronDown className='min-w-[1rem]' />
+                    </button>
+                    <button className='bg-gray-400 rounded-sm px-2 py-1 flex items-center justify-between gap-2'>
+                        <span className='text-sm truncate'>Hours</span>
+                        <IoChevronDown className='min-w-[1rem]' />
+                    </button>
                 </div>
-                <button className='bg-gray-400 rounded-sm px-2 py-1 flex items-center justify-center gap-2'>
-                    <span className='text-sm truncate'>Subject</span>
-                    <IoChevronDown className='min-w-[1rem]' />
-                </button>
-                <button className='bg-gray-400 rounded-sm px-2 py-1 flex items-center justify-center gap-2'>
-                    <span className='text-sm truncate'>Day</span>
-                    <IoChevronDown className='min-w-[1rem]' />
-                </button>
-                <button className='bg-gray-400 rounded-sm px-2 py-1 flex items-center justify-center gap-2'>
-                    <span className='text-sm truncate'>Hours</span>
-                    <IoChevronDown className='min-w-[1rem]' />
-                </button>
+                {filtersApplied && <div className='mt-8 sm:mt-[0.8rem] md:mt-[0.85rem] ml-4 items-start'>
+                    <IoReload onClick={resetSearch} className='text-base text-red-500 font-bold opacity-50 hover:opacity-100 hover:scale-125 transition-all' cursor={'pointer'}/>
+                </div>}
             </div>
-        </div>
-    )
+        )
+    }
 }
 
 export default SearchBar

--- a/src/components/TutorFeed.tsx
+++ b/src/components/TutorFeed.tsx
@@ -8,14 +8,20 @@ type TutorWithSubjects = tutor & {
 };
 
 type Props = {
+    filterName: string;
+    filterSubject: string;
+    filterDay: Date | undefined;
+    filterHours: Date | undefined;
 }
 
 const TutorFeed = (props: Props) => {
     const [tutorData, setTutorData] = React.useState<TutorWithSubjects[]>()
     const [tutorUserData, setTutorUserData] = React.useState<user[]>()
     const [tutorSubjectData, setTutorSubjectData] = React.useState<subject[][]>()
-    const [isLoading, setLoading] = React.useState(true)
-    const [loadError, setLoadError] = React.useState(false)
+    const [isLoading, setLoading] = React.useState<boolean>(true)
+    const [loadError, setLoadError] = React.useState<boolean>(false)
+    const [tutorDisplayIndexes, setTutorDisplayIndexes] = React.useState<number[]>([])
+    const nameFilter = props.filterName, subjectFilter = props.filterSubject, dayFilter = props.filterDay, hoursFilter = props.filterHours;
     
     const fetchTutorData = async () => {
         await fetch('api/tutor', {method: 'GET'})
@@ -34,6 +40,12 @@ const TutorFeed = (props: Props) => {
 
                 // Update data state
                 setTutorData(result)
+
+                // Update tutor display indexes
+                let indexes = []
+                for(let i = 0; i < result.length; i++)
+                    indexes.push(i)
+                setTutorDisplayIndexes(indexes)
             }
         })
         .catch((error) => {
@@ -125,9 +137,49 @@ const TutorFeed = (props: Props) => {
         setLoading(false)
     }
 
+    const filterTutors = () => {
+        // Return if called when loading
+        if(isLoading) return
+
+        // Display no tutors if tutorData undefined
+        if(!tutorData || !tutorUserData || !tutorSubjectData || loadError) {
+            setTutorDisplayIndexes([])
+            return
+        }
+
+        let indexes = []
+
+        // Parse filters
+        /// Name
+        for(let i = 0; i < tutorUserData.length; i++) {
+            let name = (tutorUserData[i].first_name.toLowerCase() + " " + tutorUserData[i].last_name.toLowerCase())
+            if( name.indexOf(nameFilter.toLowerCase()) != -1 ) {
+                indexes.push(i)
+            }
+            else {
+                if( indexes.indexOf(i) != -1 ) {
+                    indexes.splice(indexes.indexOf(i), 1)
+                }
+            }
+        }
+
+        /// Subject
+        
+        /// Day
+
+        /// Hours
+
+        // Set new display indexes
+        setTutorDisplayIndexes(indexes)
+    }
+
     useEffect(() => {
         fetchTutorData()
     }, [])
+
+    useEffect(() => {
+        filterTutors()
+    }, [nameFilter, subjectFilter, dayFilter, hoursFilter])
 
     if( isLoading ) {
         return <div className='mt-6'><Oval width='75' color='#9748FF' secondaryColor='#BCE3FF'/></div>
@@ -139,11 +191,11 @@ const TutorFeed = (props: Props) => {
         return (
             <div className='flex justify-center'>
                 <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 p-4 w-full sm:max-w-[75%] 2xl:max-w-[66%]'>
-                    {tutorData.map(tut => (
-                            <TutorCard key={tut.tutorID} 
-                            tutor={tut} 
-                            user={tutorUserData[tutorData.indexOf(tut)]} 
-                            subjects={tutorSubjectData[tutorData.indexOf(tut)]}/>
+                    {tutorDisplayIndexes.map(index => (
+                            <TutorCard key={tutorData[index].fk_userID} 
+                            tutor={tutorData[index]} 
+                            user={tutorUserData[index]} 
+                            subjects={tutorSubjectData[index]}/>
                     ))}
                 </div>
             </div>

--- a/src/components/TutorFeed.tsx
+++ b/src/components/TutorFeed.tsx
@@ -148,22 +148,56 @@ const TutorFeed = (props: Props) => {
         }
 
         let indexes = []
+        let blacklist = []
 
         // Parse filters
         /// Name
         for(let i = 0; i < tutorUserData.length; i++) {
             let name = (tutorUserData[i].first_name.toLowerCase() + " " + tutorUserData[i].last_name.toLowerCase())
             if( name.indexOf(nameFilter.toLowerCase()) != -1 ) {
-                indexes.push(i)
+                indexes.push(i) // NOTE: everything will be pushed if nameFilter is empty (empty value: '')
             }
-            else {
+            else { 
                 if( indexes.indexOf(i) != -1 ) {
                     indexes.splice(indexes.indexOf(i), 1)
                 }
+                blacklist.push(i)
             }
         }
 
         /// Subject
+        if(subjectFilter != '') {
+            for(let i = 0; i < tutorSubjectData.length; i++) {
+                let subjects = tutorSubjectData[i]
+                // If tutor has subjects
+                if( subjects.length > 0 ) {
+                    for(let j = 0; j < subjects.length; j++) {
+                        if( subjects[j].name == subjectFilter ) {
+                            // Subject matches, break
+                            if( indexes.indexOf(i) == -1 && blacklist.indexOf(i) == -1 )
+                                // Add to display indexes since it's not already there
+                                indexes.push(i)
+                            break
+                        }
+                        else {
+                            if( indexes.indexOf(i) != -1 ) {
+                                // Subject doesn't match, remove from display indexes
+                                indexes.splice(indexes.indexOf(i), 1)
+                            }
+
+                            // Add to blacklist if not already there
+                            if( blacklist.indexOf(i) != -1 )
+                                blacklist.push(i)
+                        }
+                    }
+                }
+                // If tutor has no subjects
+                else if( indexes.indexOf(i) != -1 ) {
+                    // Remove from display indexes if there already
+                    indexes.splice(indexes.indexOf(i), 1)
+                }
+            }
+        }
         
         /// Day
 

--- a/src/pages/api/subject/index.ts
+++ b/src/pages/api/subject/index.ts
@@ -1,0 +1,20 @@
+// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { PrismaClient, Prisma, subject } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+
+export default async function handler(
+    req: NextApiRequest,
+    res: NextApiResponse<subject[] | string>
+) {
+    switch (req.method) {
+        case 'GET':
+            const allSubjects = await prisma.subject.findMany();
+            res.status(200).json(allSubjects);
+            break;
+        default:
+            res.status(405).send('Invalid Request Method');
+    }
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -15,7 +15,7 @@ export default function Home() {
   const [nameFilter, setNameFilter] = React.useState<string>("")
   const [subjectFilter, setSubjectFilter] = React.useState<string>("")
   const [dayFilter, setDayFilter] = React.useState<Date>()
-  const [hoursFilter, setHoursFilter] = React.useState<Date>()
+  const [hourFilter, setHourFilter] = React.useState<Date>()
 
   return (
     <>
@@ -29,8 +29,8 @@ export default function Home() {
         <NavBar />
         <ActionPanel />
         <div className='p-4 flex flex-col items-center'>
-          <SearchBar setName={setNameFilter} subject={subjectFilter} setSubject={setSubjectFilter} day={dayFilter} setDay={setDayFilter} hours={hoursFilter} setHours={setHoursFilter}/>
-          <TutorFeed filterName={nameFilter} filterSubject={subjectFilter} filterDay={dayFilter} filterHours={hoursFilter}/>
+          <SearchBar setName={setNameFilter} subject={subjectFilter} setSubject={setSubjectFilter} day={dayFilter} setDay={setDayFilter} hour={hourFilter} setHour={setHourFilter}/>
+          <TutorFeed filterName={nameFilter} filterSubject={subjectFilter} filterDay={dayFilter} filterHour={hourFilter}/>
         </div>
       </main>
     </>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import Head from 'next/head'
 import Image from 'next/image'
 import { Inter } from '@next/font/google'
@@ -6,10 +7,16 @@ import ActionPanel from '../components/ActionPanel'
 import TutorFeed from '../components/TutorFeed'
 import TutorCard from '@/components/TutorCard'
 import SearchBar from '@/components/SearchBar'
+import { subject } from '@prisma/client'
 
 const inter = Inter({ subsets: ['latin'] })
 
 export default function Home() {
+  const [nameFilter, setNameFilter] = React.useState<string>("")
+  const [subjectFilter, setSubjectFilter] = React.useState<string>("")
+  const [dayFilter, setDayFilter] = React.useState<Date>()
+  const [hoursFilter, setHoursFilter] = React.useState<Date>()
+
   return (
     <>
       <Head>
@@ -22,8 +29,8 @@ export default function Home() {
         <NavBar />
         <ActionPanel />
         <div className='p-4 flex flex-col items-center'>
-          <SearchBar />
-          <TutorFeed />
+          <SearchBar setName={setNameFilter} setSubject={setSubjectFilter} setDay={setDayFilter} setHours={setHoursFilter}/>
+          <TutorFeed filterName={nameFilter} filterSubject={subjectFilter} filterDay={dayFilter} filterHours={hoursFilter}/>
         </div>
       </main>
     </>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -29,7 +29,7 @@ export default function Home() {
         <NavBar />
         <ActionPanel />
         <div className='p-4 flex flex-col items-center'>
-          <SearchBar setName={setNameFilter} setSubject={setSubjectFilter} setDay={setDayFilter} setHours={setHoursFilter}/>
+          <SearchBar setName={setNameFilter} subject={subjectFilter} setSubject={setSubjectFilter} day={dayFilter} setDay={setDayFilter} hours={hoursFilter} setHours={setHoursFilter}/>
           <TutorFeed filterName={nameFilter} filterSubject={subjectFilter} filterDay={dayFilter} filterHours={hoursFilter}/>
         </div>
       </main>


### PR DESCRIPTION
This is only missing the Filtering for day/hour. See screenshots below for examples of its implementation.

The below image is the look of the page with no search filters set:
![image](https://user-images.githubusercontent.com/38254986/234154064-597e5a3f-8ae0-4d50-aedc-46ca450fc175.png)

The below image is the look of the page with a name filter set:
![image](https://user-images.githubusercontent.com/38254986/234154157-af4a48fd-84f6-467d-8bac-68309e37f820.png)

The below image is the look of the page with a subject filter set:
![image](https://user-images.githubusercontent.com/38254986/234154342-b6862dff-8fb5-45f7-bfa3-f248b4ae88f4.png)

The below image is the look of the page with a combination of name & subject filter set:
![image](https://user-images.githubusercontent.com/38254986/234154366-642b5061-141d-43fe-94ca-a2bb697658ba.png)


The below image is the look of the dropdowns (all expanded):
![image](https://user-images.githubusercontent.com/38254986/234154454-3d612b61-5f5e-4c04-843f-b8dc17bd20ce.png)

NOTE: If we do not want dropdowns to push down tutor cards, I can do that. Please note that in the PR review if that is something you'd like for me to change. For visibility reasons, I opted to make it push down the cards for now.
NOTE 2: The red revert button appears only when filters are set, and simply resets all search filters to be put on no filter.
NOTE 3: The dropdown options are dynamically chosen. For subjects, it'll request a list of all available subjects from the database to display. For days and hours, it'll display days and hours starting from the current day/hour.